### PR TITLE
feat: add HTTPS options to start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](#configuring-a-https-certificate) section.
+Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/).
 
 ### `npm run build`
 
@@ -61,20 +61,17 @@ Created a new certificate valid for the following names 📜
 The certificate is at "./localhost+2.pem" and the key at "./localhost+2-key.pem" ✅
 ```
 
-Once you've created your locally-trusted development certificate you can provide the paths to the `cert`, `key`, and `ca` files:
+Once you've created your locally-trusted development certificate you can provide the paths to the `cert` and `key` files:
 
 ```sh
-$ npm start -- \
---key "/Users/ian/Library/Application Support/mkcert/localhost+2-key.pem" \
---cert "/Users/ian/Library/Application Support/mkcert/localhost+2.pem" \
---ca "/Users/ian/Library/Application Support/mkcert/rootCA.pem"
+$ npm start -- --cert "./localhost+2.pem" --key "./localhost+2-key.pem"
 ```
 
 Note the extra `--` used in the `npm start` script is necessary to forward the arguments to the development server process.
 
 ## Documentation
 
-Find [further documentation on the SDK](https://developers.geocortex.com/docs/workflow/sdk-web-overview/) on the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/)
+Find [further documentation on the SDK](https://developers.geocortex.com/docs/workflow/sdk-web-overview/) on the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,35 +40,6 @@ Your custom activity pack is now ready to be deployed!
 
 See the [section about deployment](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#deployment) in the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/) for more information.
 
-## Configuring a HTTPS Certificate
-
-You can create a locally-trusted development certificate that is trusted by your system using the [mkcert](https://github.com/FiloSottile/mkcert) utility. Once installed you can run:
-
-```sh
-$ mkcert -install
-Created a new local CA at "/Users/ian/Library/Application Support/mkcert" 💥
-The local CA is now installed in the system trust store! ⚡️
-The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
-
-$ mkcert localhost 127.0.0.1 ::1
-Using the local CA at "/Users/ian/Library/Application Support/mkcert" ✨
-
-Created a new certificate valid for the following names 📜
- - "localhost"
- - "127.0.0.1"
- - "::1"
-
-The certificate is at "./localhost+2.pem" and the key at "./localhost+2-key.pem" ✅
-```
-
-Once you've created your locally-trusted development certificate you can provide the paths to the `cert` and `key` files:
-
-```sh
-$ npm start -- --cert "./localhost+2.pem" --key "./localhost+2-key.pem"
-```
-
-Note the extra `--` used in the `npm start` script is necessary to forward the arguments to the development server process.
-
 ## Documentation
 
 Find [further documentation on the SDK](https://developers.geocortex.com/docs/workflow/sdk-web-overview/) on the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js).
+Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](#configuring-a-https-certificate) section.
 
 ### `npm run build`
 
@@ -39,6 +39,38 @@ Builds the activity pack for production to the `build` folder. It optimizes the 
 Your custom activity pack is now ready to be deployed!
 
 See the [section about deployment](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#deployment) in the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/) for more information.
+
+## Configuring a HTTPS Certificate
+
+You can create a locally-trusted development certificate that is trusted by your system using the [mkcert](https://github.com/FiloSottile/mkcert) utility. Once installed you can run:
+
+```sh
+$ mkcert -install
+Created a new local CA at "/Users/ian/Library/Application Support/mkcert" 💥
+The local CA is now installed in the system trust store! ⚡️
+The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
+
+$ mkcert localhost 127.0.0.1 ::1
+Using the local CA at "/Users/ian/Library/Application Support/mkcert" ✨
+
+Created a new certificate valid for the following names 📜
+ - "localhost"
+ - "127.0.0.1"
+ - "::1"
+
+The certificate is at "./localhost+2.pem" and the key at "./localhost+2-key.pem" ✅
+```
+
+Once you've created your locally-trusted development certificate you can provide the paths to the `cert`, `key`, and `ca` files:
+
+```sh
+$ npm start -- \
+--key "/Users/ian/Library/Application Support/mkcert/localhost+2-key.pem" \
+--cert "/Users/ian/Library/Application Support/mkcert/localhost+2.pem" \
+--ca "/Users/ian/Library/Application Support/mkcert/rootCA.pem"
+```
+
+Note the extra `--` used in the `npm start` script is necessary to forward the arguments to the development server process.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
         "vertigis-workflow-sdk": "bin/vertigis-workflow-sdk.js"
     },
     "scripts": {
-        "build": "cd template && npm link \"../\" --no-package-lock && npm run build",
         "create": "cross-env SDK_LOCAL_DEV=true node bin/vertigis-workflow-sdk.js create",
-        "generate": "cd template && npm link \"../\" --no-package-lock && npm run generate",
-        "start": "cd template && npm link \"../\" --no-package-lock && npm run start --",
         "test": "node ./test/index.js"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "build": "cd template && npm link \"../\" --no-package-lock && npm run build",
         "create": "cross-env SDK_LOCAL_DEV=true node bin/vertigis-workflow-sdk.js create",
         "generate": "cd template && npm link \"../\" --no-package-lock && npm run generate",
-        "start": "cd template && npm link \"../\" --no-package-lock && npm run start",
+        "start": "cd template && npm link \"../\" --no-package-lock && npm run start --",
         "test": "node ./test/index.js"
     },
     "dependencies": {
@@ -51,7 +51,8 @@
         "url-loader": "^4.1.0",
         "uuid": "^8.3.0",
         "webpack": "^5.2.0",
-        "webpack-dev-server": "^3.11.0"
+        "webpack-dev-server": "^3.11.0",
+        "yargs": "^16.1.0"
     },
     "devDependencies": {
         "@geocortex/workflow": "^5.17.1",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -19,7 +19,6 @@ const yargs = require("yargs");
 const { hideBin } = require("yargs/helpers");
 
 const argv = yargs(hideBin(process.argv)).argv;
-console.log(argv);
 
 const port = process.env.PORT || 5000;
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -15,6 +15,11 @@ process.on("unhandledRejection", (err) => {
 const webpack = require("webpack");
 const WebpackDevServer = require("webpack-dev-server");
 const webpackConfig = require("../config/webpack.config");
+const yargs = require("yargs");
+const { hideBin } = require("yargs/helpers");
+
+const argv = yargs(hideBin(process.argv)).argv;
+console.log(argv);
 
 const port = process.env.PORT || 5000;
 
@@ -28,6 +33,9 @@ const serverConfig = {
     },
     hot: false,
     https: true,
+    key: argv.key,
+    cert: argv.cert,
+    ca: argv.ca,
     open:
         process.env.SMOKE_TEST !== "true" &&
         process.env.OPEN_BROWSER !== "false",

--- a/template/README.md
+++ b/template/README.md
@@ -10,7 +10,7 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](#configuring-a-https-certificate) section.
+Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/).
 
 ### `npm run build`
 
@@ -19,38 +19,6 @@ Builds the activity pack for production to the `build` folder. It optimizes the 
 Your custom activity pack is now ready to be deployed!
 
 See the [section about deployment](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#deployment) in the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/) for more information.
-
-## Configuring a HTTPS Certificate
-
-You can create a locally-trusted development certificate that is trusted by your system using the [mkcert](https://github.com/FiloSottile/mkcert) utility. Once installed you can run:
-
-```sh
-$ mkcert -install
-Created a new local CA at "/Users/ian/Library/Application Support/mkcert" 💥
-The local CA is now installed in the system trust store! ⚡️
-The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
-
-$ mkcert localhost 127.0.0.1 ::1
-Using the local CA at "/Users/ian/Library/Application Support/mkcert" ✨
-
-Created a new certificate valid for the following names 📜
- - "localhost"
- - "127.0.0.1"
- - "::1"
-
-The certificate is at "./localhost+2.pem" and the key at "./localhost+2-key.pem" ✅
-```
-
-Once you've created your locally-trusted development certificate you can provide the paths to the `cert`, `key`, and `ca` files:
-
-```sh
-$ npm start -- \
---key "/Users/ian/Library/Application Support/mkcert/localhost+2-key.pem" \
---cert "/Users/ian/Library/Application Support/mkcert/localhost+2.pem" \
---ca "/Users/ian/Library/Application Support/mkcert/rootCA.pem"
-```
-
-Note the extra `--` used in the `npm start` script is necessary to forward the arguments to the development server process.
 
 ## Documentation
 

--- a/template/README.md
+++ b/template/README.md
@@ -10,7 +10,7 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js).
+Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](#configuring-a-https-certificate) section.
 
 ### `npm run build`
 
@@ -19,6 +19,38 @@ Builds the activity pack for production to the `build` folder. It optimizes the 
 Your custom activity pack is now ready to be deployed!
 
 See the [section about deployment](https://developers.geocortex.com/docs/workflow/sdk-web-overview/#deployment) in the [Geocortex Developer Center](https://developers.geocortex.com/docs/workflow/overview/) for more information.
+
+## Configuring a HTTPS Certificate
+
+You can create a locally-trusted development certificate that is trusted by your system using the [mkcert](https://github.com/FiloSottile/mkcert) utility. Once installed you can run:
+
+```sh
+$ mkcert -install
+Created a new local CA at "/Users/ian/Library/Application Support/mkcert" 💥
+The local CA is now installed in the system trust store! ⚡️
+The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
+
+$ mkcert localhost 127.0.0.1 ::1
+Using the local CA at "/Users/ian/Library/Application Support/mkcert" ✨
+
+Created a new certificate valid for the following names 📜
+ - "localhost"
+ - "127.0.0.1"
+ - "::1"
+
+The certificate is at "./localhost+2.pem" and the key at "./localhost+2-key.pem" ✅
+```
+
+Once you've created your locally-trusted development certificate you can provide the paths to the `cert`, `key`, and `ca` files:
+
+```sh
+$ npm start -- \
+--key "/Users/ian/Library/Application Support/mkcert/localhost+2-key.pem" \
+--cert "/Users/ian/Library/Application Support/mkcert/localhost+2.pem" \
+--ca "/Users/ian/Library/Application Support/mkcert/rootCA.pem"
+```
+
+Note the extra `--` used in the `npm start` script is necessary to forward the arguments to the development server process.
 
 ## Documentation
 


### PR DESCRIPTION
Adds `cert`, `key`, and `ca` options to the `start` script to support passing in a HTTPS cert to the dev server config.