### PR TITLE
fix: switch to jsdoc style block tags in templates

### DIFF
--- a/lib/templates/activity.ts
+++ b/lib/templates/activity.ts
@@ -2,28 +2,35 @@ import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHand
 
 /** An interface that defines the inputs of the activity. */
 export interface FooInputs {
-    // @displayName Input 1
-    // @description The first input to the activity.
-    // @required
+    /**
+     * @displayName Input 1
+     * @description The first input to the activity.
+     * @required
+     */
     input1: string;
 
-    // @displayName Input 2
-    // @description The second input to the activity.
+    /**
+     * @displayName Input 2
+     * @description The second input to the activity.
+     */
     input2?: number;
 }
 
 /** An interface that defines the outputs of the activity. */
 export interface FooOutputs {
-    /** A result of the activity. */
-    // @description The result of the activity.
+    /**
+     * @description The result of the activity.
+     */
     result: string;
 }
 
-// @displayName <name>
-// @category Custom Activities
-// @description <description>
+/**
+ * @displayName <name>
+ * @category Custom Activities
+ * @description <description>
+ */
 export class Foo implements IActivityHandler {
-    // Perform the execution logic of the activity.
+    /** Perform the execution logic of the activity. */
     execute(inputs: FooInputs): FooOutputs {
         return {
             result: `input1: ${inputs.input1}, input2: ${

--- a/lib/templates/element.tsx
+++ b/lib/templates/element.tsx
@@ -39,11 +39,13 @@ const Foo = (props: CustomFormElementProps) => {
     );
 };
 
-// @displayName Register <name> Form Element
-// @category Custom Activities
-// @description <description>
+/**
+ * @displayName Register <name> Form Element
+ * @category Custom Activities
+ * @description <description>
+ */
 export class RegisterFooElement extends RegisterCustomFormElementBase {
-    // Perform the execution logic of the activity.
+    /** Perform the execution logic of the activity. */
     execute() {
         this.register("<name>", Foo);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -207,8 +207,8 @@ async function testGenerateActivity() {
             const activityContentAssertions = [
                 "export interface FooNameInputs {",
                 "export interface FooNameOutputs {",
-                "// @displayName FooName",
-                "// @description FooName description",
+                "* @displayName FooName",
+                "* @description FooName description",
                 "export class FooName implements IActivityHandler {",
                 "execute(inputs: FooNameInputs): FooNameOutputs {",
             ];
@@ -275,8 +275,8 @@ async function testGenerateActivity() {
 
             const elementContentAssertions = [
                 "const BarName = (props",
-                "// @displayName Register BarName Form Element",
-                "// @description BarName description",
+                "* @displayName Register BarName Form Element",
+                "* @description BarName description",
                 "export class RegisterBarNameElement extends RegisterCustomFormElementBase {",
                 'this.register("BarName", BarName)',
             ];
@@ -307,10 +307,11 @@ function testActivityPackMetadataGeneration() {
     const projectUuid = getProjectUuid();
     const metadata = require(metadataPath);
 
-    assert.strictEqual(
-        JSON.stringify(metadata),
-        `{"activities":[{"action":"uuid:${projectUuid}::RegisterBarNameElement","suite":"uuid:${projectUuid}","displayName":"Register BarName Form Element","description":"BarName description","category":"Custom Activities","tags":{},"inputs":{},"outputs":{}},{"action":"uuid:${projectUuid}::FooName","suite":"uuid:${projectUuid}","displayName":"FooName","description":"FooName description","category":"Custom Activities","tags":{},"inputs":{"input1":{"name":"input1","displayName":"Input 1","description":"The first input to the activity.","placeholder":"","typeName":"string","defaultValue":"","defaultExpressionHint":"","isRequired":true,"noExpressions":false},"input2":{"name":"input2","displayName":"Input 2","description":"The second input to the activity.","placeholder":"","typeName":"number","defaultValue":"","defaultExpressionHint":"","isRequired":false,"noExpressions":false}},"outputs":{"result":{"name":"result","displayName":"Result","description":"The result of the activity.","placeholder":"","typeName":"string","defaultValue":"","defaultExpressionHint":"","isRequired":false,"noExpressions":false}}}]}`,
-        "expected activity metadata output to match"
+    assert.deepStrictEqual(
+        metadata,
+        JSON.parse(
+            `{"activities":[{"action":"uuid:${projectUuid}::RegisterBarNameElement","suite":"uuid:${projectUuid}","displayName":"Register BarName Form Element","description":"BarName description","category":"Custom Activities","tags":{},"inputs":{},"outputs":{}},{"action":"uuid:${projectUuid}::FooName","suite":"uuid:${projectUuid}","displayName":"FooName","description":"FooName description","category":"Custom Activities","tags":{},"inputs":{"input1":{"name":"input1","displayName":"Input 1","description":"The first input to the activity.","placeholder":"","typeName":"string","defaultValue":"","defaultExpressionHint":"","isRequired":true,"noExpressions":false},"input2":{"name":"input2","displayName":"Input 2","description":"The second input to the activity.","placeholder":"","typeName":"number","defaultValue":"","defaultExpressionHint":"","isRequired":false,"noExpressions":false}},"outputs":{"result":{"name":"result","displayName":"Result","description":"The result of the activity.","placeholder":"","typeName":"string","defaultValue":"","defaultExpressionHint":"","isRequired":false,"noExpressions":false}}}]}`
+        )
     );
 }
 


### PR DESCRIPTION
Using JSDoc comments instead of double slash comments improves the legibility and integration in developer tooling:

Before:
![image](https://user-images.githubusercontent.com/6355370/98427374-bec5b580-2051-11eb-8b11-b6b4cd5a07d7.png)

After:
![image](https://user-images.githubusercontent.com/6355370/98427397-d3a24900-2051-11eb-9ccd-d4a75b6a82b9.png)
