### PR TITLE
feat: validate metatags during build

### DIFF
--- a/lib/GenerateActivityMetadataPlugin.js
+++ b/lib/GenerateActivityMetadataPlugin.js
@@ -43,17 +43,26 @@ class GenerateActivityMetadataPlugin {
                     stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
                 },
                 async () => {
-                    const manifest = await generateActivityManifest();
-                    const manifestString = JSON.stringify(
-                        manifest,
-                        null,
-                        process.env.NODE_ENV === "development" ? 2 : 0
-                    );
+                    try {
+                        const manifest = await generateActivityManifest();
+                        const manifestString = JSON.stringify(
+                            manifest,
+                            null,
+                            process.env.NODE_ENV === "development" ? 2 : 0
+                        );
 
-                    compilation.emitAsset(
-                        "activitypack.json",
-                        new sources.RawSource(manifestString)
-                    );
+                        compilation.emitAsset(
+                            "activitypack.json",
+                            new sources.RawSource(manifestString)
+                        );
+                    } catch (err) {
+                        // We rearrange the properties a bit here because webpack logs it as:
+                        //   ERROR in ${err.message}
+                        //   ${err.details}
+                        err.details = err.message;
+                        err.message = pluginName;
+                        compilation.errors.push(err);
+                    }
                 }
             );
         });

--- a/lib/InvalidMetatagsError.js
+++ b/lib/InvalidMetatagsError.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const { WebpackError } = require("webpack");
+
+module.exports = class InvalidMetatagsError extends WebpackError {
+    /** @param {string} message Error message */
+    constructor(message) {
+        super(message);
+        this.name = "InvalidMetatagsError";
+        this.hideStack = true;
+
+        Error.captureStackTrace(this, this.constructor);
+    }
+};

--- a/lib/compilerUtils.js
+++ b/lib/compilerUtils.js
@@ -275,9 +275,30 @@ function addCamelSpace(text) {
     return result.substr(0, 1).toUpperCase() + result.substr(1);
 }
 
+const incompatibleMetatags = [
+    ["supportedApps", "unsupportedApps"],
+    ["clientOnly", "serverOnly"],
+];
+
+function validateMetatags(meta, itemType) {
+    if (!meta) {
+        return;
+    }
+    for (const pair of incompatibleMetatags) {
+        if (meta[pair[0]] && meta[pair[1]]) {
+            throw new Error(
+                `You cannot include the @${pair[0]} and @${pair[1]} metatags on the same ${itemType}.`
+            );
+        }
+    }
+}
+
 function adaptArgumentMaterial(material) {
+    validateMetatags(material.meta, "activity input");
+
     const name =
         getFirst(material.meta && material.meta.name) || material.name || "";
+
     return {
         name: name,
         displayName:
@@ -390,6 +411,8 @@ function parseFile(sourceText, fileName, suiteUuid) {
 }
 
 function adaptActivityMaterial(material) {
+    validateMetatags(material.meta, "activity");
+
     const inputs = {};
     const outputs = {};
     const result = {

--- a/lib/compilerUtils.js
+++ b/lib/compilerUtils.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const ts = require("typescript");
+const InvalidMetatagsError = require("./InvalidMetatagsError");
 
 // The logic in this module was copied from the GXWF Designer.
 
@@ -286,7 +287,7 @@ function validateMetatags(meta, itemType) {
     }
     for (const pair of incompatibleMetatags) {
         if (meta[pair[0]] && meta[pair[1]]) {
-            throw new Error(
+            throw new InvalidMetatagsError(
                 `You cannot include the @${pair[0]} and @${pair[1]} metatags on the same ${itemType}.`
             );
         }

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -82,7 +82,7 @@ const updateTemplateContent = (rootPath) => {
 };
 
 const installNpmDeps = (rootPath) => {
-    console.log(`Installing packages. This might take a couple minutes.\n`);
+    console.log(`Installing packages. This might take a couple of minutes.\n`);
     const selfVersion = require(path.join(rootDir, "package.json")).version;
 
     // First install existing deps.


### PR DESCRIPTION
The activity pack build will now fail if an Activity or Activity Input has an invalid combination of meta tags present.

* `@clientOnly` and `@serverOnly` - These are mutually exclusive.
* `@supportedApps` and `@unsupportedApps` - You can only use a whitelist or blacklist, not both.