### PR TITLE
fix: Restore support for imported and union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Geocortex Workflow SDK
 
 ![CI/CD](https://github.com/geocortex/vertigis-workflow-sdk/workflows/CI/CD/badge.svg)
+[![npm](https://img.shields.io/npm/v/@vertigis/workflow-sdk)](https://www.npmjs.com/package/@vertigis/workflow-sdk)
 
 This SDK makes it easy to create custom activity packs for [Geocortex Workflow](https://www.geocortex.com/products/geocortex-workflow/).
 

--- a/lib/compilerUtils.js
+++ b/lib/compilerUtils.js
@@ -154,7 +154,24 @@ function getParameterMetadata(param, properties, inputType) {
     const props = {};
     for (const paramProp of properties) {
         const paramName = paramProp.getName();
-        const paramType = paramProp.getTypeAtLocation(param).getText();
+
+        // Try to get the type via the property signature
+        // This provides better type detail than getTypeAtLocation() for things like union types
+        let paramType;
+        const valueDeclaration = paramProp.getValueDeclaration();
+        if (valueDeclaration && Node.isPropertySignature(valueDeclaration)) {
+            const structure = valueDeclaration.getStructure();
+            if (typeof structure.type === "string") {
+                paramType = structure.type;
+            }
+        }
+
+        if (!paramType) {
+            // Fallback to getTypeAtLocation()
+            // We need to pass in the param to getText() to avoid inline imports in the type name
+            // See https://github.com/dsherret/ts-morph/issues/453#issuecomment-427405736
+            paramType = paramProp.getTypeAtLocation(param).getText(param);
+        }
 
         const paramTags = paramProp.compilerSymbol.getJsDocTags().reduce(
             (acc, tag) => ({

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -334,7 +334,7 @@ function testActivityPackMetadataGeneration() {
                         description: "The second input to the activity.",
                         displayName: "Input 2",
                         name: "input2",
-                        typeName: "number | undefined",
+                        typeName: "number",
                     },
                 },
                 outputs: {


### PR DESCRIPTION
The `getTypeAtLocation(param).getText()` approach introduced at `2.0` to get activity input/output type names doesn't preserve union type information and includes inline import statements for imported types which cannot be processed by Workflow Designer.

This PR goes back to using the raw type from the source as the type name.