### PR TITLE
fix: make @arcgis package external

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     externals: [
         /^dojo\/.+$/,
         /^esri\/.+$/,
+        /^@arcgis\/.+$/,
         /^@geocortex\/.+$/,
         /^@vertigis\/.+$/,
         "react",


### PR DESCRIPTION
Currently if you add `@arcgis/core` as a dependency of our activity pack it will be included in the built output (which we don't want). This PR marks `@arcgis/` imports as external.