### PR TITLE
fix: use elementId as fallback displayName of form elements

### DIFF
--- a/lib/compilerUtils.js
+++ b/lib/compilerUtils.js
@@ -506,7 +506,7 @@ function getElementMetadata(registrationDeclaration, suiteUuid) {
     return {
         deprecated: elementTags.deprecated,
         description: elementTags.description,
-        displayName: elementTags.displayName || elementId,
+        displayName: elementTags.displayName || toPascalCase(elementId),
         helpUrl: elementTags.helpUrl,
         id: elementId,
         inputs,

--- a/lib/compilerUtils.js
+++ b/lib/compilerUtils.js
@@ -506,7 +506,7 @@ function getElementMetadata(registrationDeclaration, suiteUuid) {
     return {
         deprecated: elementTags.deprecated,
         description: elementTags.description,
-        displayName: elementTags.displayName,
+        displayName: elementTags.displayName || elementId,
         helpUrl: elementTags.helpUrl,
         id: elementId,
         inputs,


### PR DESCRIPTION
If a for element does not provide a `@displayName` it shows up as "Custom" in the designer toolbox. Having multiple "Custom" entries in the toolbox is confusing. Using the `elementId` is a reasonable fallback and it roughly matches what we do for activities.