### PR TITLE
feat!: Upgrade to workflow 5.33.1

### DIFF
--- a/lib/templates/activity.ts
+++ b/lib/templates/activity.ts
@@ -1,4 +1,4 @@
-import type { IActivityHandler } from "@vertigis/workflow/runtime";
+import type { IActivityHandler } from "@vertigis/workflow";
 
 /** An interface that defines the inputs of the activity. */
 interface FooInputs {

--- a/lib/templates/element.tsx
+++ b/lib/templates/element.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-import {
-    FormElementProps,
-    FormElementRegistration,
-} from "@vertigis/workflow/runtime";
+import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
 
 /**
  * The generic type argument provided to `FormElementProps<T>` controls the type

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^16.11.32",
-        "@vertigis/workflow": "^5.32.1",
+        "@vertigis/workflow": "..\\vertigis-workflow-5.33.0.tgz",
         "conventional-changelog-conventionalcommits": "^4.5.0",
         "cross-env": "^7.0.3",
         "execa": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^16.11.32",
-        "@vertigis/workflow": "..\\vertigis-workflow-5.33.0.tgz",
+        "@vertigis/workflow": "^5.33.0",
         "conventional-changelog-conventionalcommits": "^4.5.0",
         "cross-env": "^7.0.3",
         "execa": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^16.11.32",
-        "@vertigis/workflow": "^5.33.0",
+        "@vertigis/workflow": "^5.33.1",
         "conventional-changelog-conventionalcommits": "^4.5.0",
         "cross-env": "^7.0.3",
         "execa": "^5.0.0",

--- a/test/unit/compilerUtils.test.js
+++ b/test/unit/compilerUtils.test.js
@@ -589,7 +589,7 @@ describe("getProjectMetadata", () => {
     describe("elements", () => {
         it("passes basic sanity", () => {
             const activitySource = `
-            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow/runtime";
+            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
             import React from "react";
 
             interface Props extends FormElementProps<string> {
@@ -677,7 +677,7 @@ describe("getProjectMetadata", () => {
 
         it("includes elements with basic props interface", () => {
             const activitySource = `
-            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow/runtime";
+            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
             import React from "react";
 
             interface Props extends FormElementProps<string> {}
@@ -718,7 +718,7 @@ describe("getProjectMetadata", () => {
 
         it("throws error for invalid `component` value", () => {
             const activitySource = `
-            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow/runtime";
+            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
 
             const Foo = 42;
 
@@ -740,7 +740,7 @@ describe("getProjectMetadata", () => {
 
         it("throws error for shorthand `id` expression", () => {
             const activitySource = `
-            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow/runtime";
+            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
 
             const Foo = () => null;
 
@@ -764,7 +764,7 @@ describe("getProjectMetadata", () => {
 
         it("throws error for incorrect type of `id` value", () => {
             const activitySource = `
-            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow/runtime";
+            import { FormElementProps, FormElementRegistration } from "@vertigis/workflow";
 
             const Foo = () => null;
 


### PR DESCRIPTION
Package references to `@vertigis/workflow` will no longer include the `/runtime` subdirectory.