### PR TITLE
fix: fix semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/jest": "^29.5.5",
         "@types/node": "^18.16.19",
         "@vertigis/workflow": "^5.35.1",
-        "conventional-changelog-conventionalcommits": "^7.0.2",
+        "conventional-changelog-conventionalcommits": "^6.1.0",
         "cross-env": "^7.0.3",
         "execa": "^5.0.0",
         "husky": "^4.3.6",


### PR DESCRIPTION
Revert `conventional-changelog-conventionalcommits` to `6.1.0`