### PR TITLE
fix: use semantic-release v23

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,4 +56,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npx semantic-release@^19
+              run: npx semantic-release@^23


### PR DESCRIPTION
`semantic-release` was exiting after the following without actually releasing
```
› ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
```

Upgrading to v23 to see if it works. 