### PR TITLE
fix: issue resolving correct react version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "ts-morph": "~9.1.0",
                 "url-loader": "~4.1.1",
                 "webpack": "~5.94.0",
-                "webpack-dev-server": "~5.1.0",
+                "webpack-dev-server": "~5.2.0",
                 "yargs": "~17.7.2"
             },
             "bin": {
@@ -40,7 +40,7 @@
                 "@babel/preset-typescript": "7.26.0",
                 "@types/jest": "^29.5.12",
                 "@types/node": "^20.11.30",
-                "@vertigis/workflow": "^5.43.0",
+                "@vertigis/workflow": "^5.45.1",
                 "conventional-changelog-conventionalcommits": "^7.0.2",
                 "cross-env": "^7.0.3",
                 "execa": "^9.0.0",
@@ -88,12 +88,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "license": "MIT",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -384,16 +385,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "license": "MIT",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -421,24 +424,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.7",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.7"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.27.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-            "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+            "version": "7.27.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+            "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.26.8"
+                "@babel/types": "^7.27.3"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1706,25 +1710,23 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.7",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
-            "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.26.8",
-                "@babel/types": "^7.26.8"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1749,13 +1751,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-            "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+            "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2719,8 +2721,9 @@
         },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
@@ -2738,8 +2741,9 @@
         },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
@@ -2751,14 +2755,16 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+            "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
@@ -2766,14 +2772,16 @@
         },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/react": {
             "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
@@ -2796,8 +2804,9 @@
         },
         "node_modules/@emotion/serialize": {
             "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
@@ -2809,14 +2818,16 @@
         },
         "node_modules/@emotion/sheet": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/styled": {
             "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+            "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
@@ -2838,14 +2849,16 @@
         },
         "node_modules/@emotion/unitless": {
             "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
@@ -2853,14 +2866,16 @@
         },
         "node_modules/@emotion/utils": {
             "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2908,8 +2923,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2959,7 +2975,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "xss": "1.0.13"
             },
@@ -3029,19 +3044,6 @@
                 "@floating-ui/utils": "^0.2.8"
             }
         },
-        "node_modules/@floating-ui/react-dom": {
-            "version": "2.1.2",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@floating-ui/dom": "^1.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
         "node_modules/@floating-ui/utils": {
             "version": "0.2.9",
             "dev": true,
@@ -3061,8 +3063,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3095,8 +3098,9 @@
         },
         "node_modules/@icons/material": {
             "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "react": "*"
@@ -3748,42 +3752,11 @@
                 "@lit-labs/ssr-dom-shim": "^1.2.0"
             }
         },
-        "node_modules/@mui/base": {
-            "version": "5.0.0-beta.40",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@floating-ui/react-dom": "^2.0.8",
-                "@mui/types": "^7.2.14",
-                "@mui/utils": "^5.15.14",
-                "@popperjs/core": "^2.11.8",
-                "clsx": "^2.1.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@mui/core-downloads-tracker": {
-            "version": "5.16.14",
+            "version": "6.4.12",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.12.tgz",
+            "integrity": "sha512-M7IkG4LqSJfkY+thlQQHNkcS5NdmMDwLq/2RKoW40XR0mv/2BYb6X8fRnyaxP4zGdPD2M4MQdbzKihSVormJ7Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "funding": {
                 "type": "opencollective",
@@ -3791,24 +3764,25 @@
             }
         },
         "node_modules/@mui/icons-material": {
-            "version": "5.15.15",
+            "version": "6.4.12",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.12.tgz",
+            "integrity": "sha512-ILTe3A2te0+Vb9TG4P1AZVmZFOjDDCV/b2nBmV1rNOmSu3Q/xkHghW+yMhMffwHcXklMlcajMlc4iFSkPbrTKw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9"
+                "@babel/runtime": "^7.26.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@mui/material": "^5.0.0",
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0"
+                "@mui/material": "^6.4.12",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -3817,26 +3791,27 @@
             }
         },
         "node_modules/@mui/material": {
-            "version": "5.15.15",
+            "version": "6.4.12",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.12.tgz",
+            "integrity": "sha512-VqoLNS5UaNqoS1FybezZR/PaAvzbTmRe0Mx//afXbolIah43eozpX2FckaFffLvMoiSIyxx1+AMHyENTr2Es0Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@mui/base": "5.0.0-beta.40",
-                "@mui/core-downloads-tracker": "^5.15.15",
-                "@mui/system": "^5.15.15",
-                "@mui/types": "^7.2.14",
-                "@mui/utils": "^5.15.14",
-                "@types/react-transition-group": "^4.4.10",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.26.0",
+                "@mui/core-downloads-tracker": "^6.4.12",
+                "@mui/system": "^6.4.12",
+                "@mui/types": "~7.2.24",
+                "@mui/utils": "^6.4.9",
+                "@popperjs/core": "^2.11.8",
+                "@types/react-transition-group": "^4.4.12",
+                "clsx": "^2.1.1",
                 "csstype": "^3.1.3",
                 "prop-types": "^15.8.1",
-                "react-is": "^18.2.0",
+                "react-is": "^19.0.0",
                 "react-transition-group": "^4.4.5"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3845,9 +3820,117 @@
             "peerDependencies": {
                 "@emotion/react": "^11.5.0",
                 "@emotion/styled": "^11.3.0",
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "@mui/material-pigment-css": "^6.4.12",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@mui/material-pigment-css": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/@mui/private-theming": {
+            "version": "6.4.9",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+            "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/utils": "^6.4.9",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/@mui/styled-engine": {
+            "version": "6.4.11",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.11.tgz",
+            "integrity": "sha512-74AUmlHXaGNbyUqdK/+NwDJOZqgRQw6BcNvhoWYLq3LGbLTkE+khaJ7soz6cIabE4CPYqO2/QAIU1Z/HEjjpcw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/sheet": "^1.4.0",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/@mui/system": {
+            "version": "6.4.12",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.12.tgz",
+            "integrity": "sha512-fgEfm1qxpKCztndESeL1L0sLwA2c7josZ2w42D8OM3pbLee4bH2twEjoMo6qf7z2rNw1Uc9EU9haXeMoq0oTdQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/private-theming": "^6.4.9",
+                "@mui/styled-engine": "^6.4.11",
+                "@mui/types": "~7.2.24",
+                "@mui/utils": "^6.4.9",
+                "clsx": "^2.1.1",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@emotion/react": {
@@ -3861,18 +3944,72 @@
                 }
             }
         },
-        "node_modules/@mui/private-theming": {
-            "version": "5.16.14",
+        "node_modules/@mui/material/node_modules/@mui/types": {
+            "version": "7.2.24",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
             "dev": true,
-            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/@mui/utils": {
+            "version": "6.4.9",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+            "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+            "dev": true,
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@mui/utils": "^5.16.14",
+                "@babel/runtime": "^7.26.0",
+                "@mui/types": "~7.2.24",
+                "@types/prop-types": "^15.7.14",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-is": "^19.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material/node_modules/react-is": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+            "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@mui/private-theming": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.1.1.tgz",
+            "integrity": "sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.27.1",
+                "@mui/utils": "^7.1.1",
                 "prop-types": "^15.8.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3889,18 +4026,21 @@
             }
         },
         "node_modules/@mui/styled-engine": {
-            "version": "5.16.14",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.1.1.tgz",
+            "integrity": "sha512-R2wpzmSN127j26HrCPYVQ53vvMcT5DaKLoWkrfwUYq3cYytL6TQrCH8JBH3z79B6g4nMZZVoaXrxO757AlShaw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
+                "@babel/runtime": "^7.27.1",
                 "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/sheet": "^1.4.0",
                 "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3921,22 +4061,23 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "5.16.14",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.1.1.tgz",
+            "integrity": "sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@mui/private-theming": "^5.16.14",
-                "@mui/styled-engine": "^5.16.14",
-                "@mui/types": "^7.2.15",
-                "@mui/utils": "^5.16.14",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.27.1",
+                "@mui/private-theming": "^7.1.1",
+                "@mui/styled-engine": "^7.1.1",
+                "@mui/types": "^7.4.3",
+                "@mui/utils": "^7.1.1",
+                "clsx": "^2.1.1",
                 "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3961,10 +4102,14 @@
             }
         },
         "node_modules/@mui/types": {
-            "version": "7.2.21",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.3.tgz",
+            "integrity": "sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.27.1"
+            },
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -3975,20 +4120,21 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "5.16.14",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.1.1.tgz",
+            "integrity": "sha512-BkOt2q7MBYl7pweY2JWwfrlahhp+uGLR8S+EhiyRaofeRYUWL2YKbSGQvN4hgSN1i8poN0PaUiii1kEMrchvzg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@mui/types": "^7.2.15",
-                "@types/prop-types": "^15.7.12",
+                "@babel/runtime": "^7.27.1",
+                "@mui/types": "^7.4.3",
+                "@types/prop-types": "^15.7.14",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "react-is": "^19.0.0"
+                "react-is": "^19.1.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4005,23 +4151,26 @@
             }
         },
         "node_modules/@mui/utils/node_modules/react-is": {
-            "version": "19.0.0",
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+            "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@mui/x-data-grid": {
-            "version": "7.2.0",
+            "version": "7.29.6",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.29.6.tgz",
+            "integrity": "sha512-2x3+jaqqiia3FjTcsN2PjlnVKHiVFqrDvcJ6p/PFAjI75uSG6rhOhx4bwrJxm3+TWFnZD5Ir8Ln9MYLiPjIEUQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/system": "^5.15.14",
-                "@mui/utils": "^5.15.14",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-internals": "7.29.0",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "reselect": "^4.1.8"
+                "reselect": "^5.1.1",
+                "use-sync-external-store": "^1.0.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -4031,49 +4180,139 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@mui/material": "^5.15.14",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "@emotion/react": "^11.9.0",
+                "@emotion/styled": "^11.8.1",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@mui/x-data-grid-pro": {
-            "version": "7.2.0",
+            "version": "7.29.6",
+            "resolved": "https://registry.npmjs.org/@mui/x-data-grid-pro/-/x-data-grid-pro-7.29.6.tgz",
+            "integrity": "sha512-VNRTqrHEZqlTiAeBJbUJgcNGvkA6oghqaibLqwaQY3xhZHLjpcVFPDYgGBl2AKOmo1kl+QDR5K9NsrGnjT5Lvw==",
             "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/system": "^5.15.14",
-                "@mui/utils": "^5.15.14",
-                "@mui/x-data-grid": "7.2.0",
-                "@mui/x-license": "7.2.0",
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-data-grid": "7.29.6",
+                "@mui/x-internals": "7.29.0",
+                "@mui/x-license": "7.29.1",
                 "@types/format-util": "^1.0.4",
-                "clsx": "^2.1.0",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
-                "reselect": "^4.1.8"
+                "reselect": "^5.1.1"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "@mui/material": "^5.15.14",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "@emotion/react": "^11.9.0",
+                "@emotion/styled": "^11.8.1",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/x-date-pickers": {
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.29.4.tgz",
+            "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-internals": "7.29.0",
+                "@types/react-transition-group": "^4.4.11",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.9.0",
+                "@emotion/styled": "^11.8.1",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+                "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+                "dayjs": "^1.10.7",
+                "luxon": "^3.0.2",
+                "moment": "^2.29.4",
+                "moment-hijri": "^2.1.2 || ^3.0.0",
+                "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "date-fns": {
+                    "optional": true
+                },
+                "date-fns-jalali": {
+                    "optional": true
+                },
+                "dayjs": {
+                    "optional": true
+                },
+                "luxon": {
+                    "optional": true
+                },
+                "moment": {
+                    "optional": true
+                },
+                "moment-hijri": {
+                    "optional": true
+                },
+                "moment-jalaali": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@mui/x-date-pickers-pro": {
-            "version": "7.2.0",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@mui/x-date-pickers-pro/-/x-date-pickers-pro-7.29.4.tgz",
+            "integrity": "sha512-ifQliSaaLvSQLX8ys6loC0n9klza+BRbcQLC4f3/QLNC6w40sTEV3HEDJQUZChJCUk0bPqoxVuDKGTvgc02yhg==",
             "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/base": "^5.0.0-beta.40",
-                "@mui/system": "^5.15.14",
-                "@mui/utils": "^5.15.14",
-                "@mui/x-date-pickers": "7.2.0",
-                "@mui/x-license": "7.2.0",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-date-pickers": "7.29.4",
+                "@mui/x-internals": "7.29.0",
+                "@mui/x-license": "7.29.1",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
             },
@@ -4083,16 +4322,17 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14",
-                "date-fns": "^2.25.0 || ^3.2.0",
-                "date-fns-jalali": "^2.13.0-0",
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+                "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
                 "dayjs": "^1.10.7",
                 "luxon": "^3.0.2",
                 "moment": "^2.29.4",
-                "moment-hijri": "^2.1.2",
+                "moment-hijri": "^2.1.2 || ^3.0.0",
                 "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@emotion/react": {
@@ -4124,20 +4364,15 @@
                 }
             }
         },
-        "node_modules/@mui/x-date-pickers-pro/node_modules/@mui/x-date-pickers": {
-            "version": "7.2.0",
+        "node_modules/@mui/x-internals": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+            "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/base": "^5.0.0-beta.40",
-                "@mui/system": "^5.15.14",
-                "@mui/utils": "^5.15.14",
-                "@types/react-transition-group": "^4.4.10",
-                "clsx": "^2.1.0",
-                "prop-types": "^15.8.1",
-                "react-transition-group": "^4.4.5"
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -4147,93 +4382,39 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@emotion/react": "^11.9.0",
-                "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14",
-                "date-fns": "^2.25.0 || ^3.2.0",
-                "date-fns-jalali": "^2.13.0-0",
-                "dayjs": "^1.10.7",
-                "luxon": "^3.0.2",
-                "moment": "^2.29.4",
-                "moment-hijri": "^2.1.2",
-                "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/react": {
-                    "optional": true
-                },
-                "@emotion/styled": {
-                    "optional": true
-                },
-                "date-fns": {
-                    "optional": true
-                },
-                "date-fns-jalali": {
-                    "optional": true
-                },
-                "dayjs": {
-                    "optional": true
-                },
-                "luxon": {
-                    "optional": true
-                },
-                "moment": {
-                    "optional": true
-                },
-                "moment-hijri": {
-                    "optional": true
-                },
-                "moment-jalaali": {
-                    "optional": true
-                }
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@mui/x-license": {
-            "version": "7.2.0",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-7.29.1.tgz",
+            "integrity": "sha512-+6D4/2IVal8Gfzu7iZS0ZJgL5cMes0gES+uK9D8I4rlMjPQ779N/rXYMe42mGQZbZuRpoqwSq6VLQx3Gr3SkLQ==",
             "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/utils": "^5.15.14"
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-internals": "7.29.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@mui/x-license-pro": {
-            "version": "6.10.2",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.22.6",
-                "@mui/utils": "^5.13.7"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0"
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@mui/x-tree-view": {
-            "version": "7.2.0",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-7.29.1.tgz",
+            "integrity": "sha512-hjfgDVxiuRr5BYKEI2bemkqMaWbh/YIVRJ01OxEU5An2hL5DKAA/Ziv6UV9jse3nTXJwOGkZ3uj0ofoxb9iznQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@mui/base": "^5.0.0-beta.40",
-                "@mui/system": "^5.15.14",
-                "@mui/utils": "^5.15.14",
-                "@types/react-transition-group": "^4.4.10",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.25.7",
+                "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+                "@mui/x-internals": "7.29.0",
+                "@types/react-transition-group": "^4.4.11",
+                "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
                 "react-transition-group": "^4.4.5"
             },
@@ -4247,9 +4428,18 @@
             "peerDependencies": {
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
-                "@mui/material": "^5.15.14",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -4298,8 +4488,9 @@
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "funding": {
                 "type": "opencollective",
@@ -4508,8 +4699,9 @@
         },
         "node_modules/@types/format-util": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/format-util/-/format-util-1.0.4.tgz",
+            "integrity": "sha512-xrCYOdHh5zA3LUrn6CvspYwlzSWxPso11Lx32WnAG6KvLCRecKZ/Rh21PLXUkzUFsQmrGcx/traJAFjR6dVS5Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@types/gensync": {
@@ -4540,7 +4732,8 @@
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.16",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+            "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -4607,9 +4800,10 @@
             "license": "MIT"
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.14",
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@types/qs": {
@@ -4621,19 +4815,20 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "18.3.18",
+            "version": "19.1.8",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+            "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-transition-group": {
             "version": "4.4.12",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+            "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "@types/react": "*"
@@ -5085,17 +5280,18 @@
             }
         },
         "node_modules/@vertigis/react-ui": {
-            "version": "16.7.2",
+            "version": "19.5.1",
+            "resolved": "https://registry.npmjs.org/@vertigis/react-ui/-/react-ui-19.5.1.tgz",
+            "integrity": "sha512-66ZXFEpsN9XXd5DmkbtFd2wOV3pK3bvMT/NX5s+o4A4PHNUYXp0+GD+zweRCfLzFj8NgJdSSkcHdTwRizpzgkw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@mui/icons-material": "5.15.15",
-                "@mui/material": "5.15.15",
-                "@mui/x-data-grid-pro": "7.2.0",
-                "@mui/x-date-pickers-pro": "7.2.0",
-                "@mui/x-license-pro": "6.10.2",
-                "@mui/x-tree-view": "7.2.0",
+                "@mui/icons-material": "^6.4.0",
+                "@mui/material": "^6.4.0",
+                "@mui/x-data-grid-pro": "^7.24.0",
+                "@mui/x-date-pickers-pro": "^7.24.0",
+                "@mui/x-license": "^7.24.1",
+                "@mui/x-tree-view": "^7.24.0",
                 "autosuggest-highlight": "^3.3.4",
                 "clsx": "^2.1.0",
                 "color": "^4.2.3",
@@ -5109,14 +5305,16 @@
                 "@emotion/react": "*",
                 "@emotion/styled": "*",
                 "@esri/arcgis-html-sanitizer": "^4.0.3",
-                "react": ">= 17 < 19",
-                "react-dom": ">= 17 < 19"
+                "@mui/system": "*",
+                "react": ">= 18 < 20",
+                "react-dom": ">= 18 < 20"
             }
         },
         "node_modules/@vertigis/react-ui/node_modules/marked": {
             "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+            "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
@@ -5127,8 +5325,9 @@
         },
         "node_modules/@vertigis/react-ui/node_modules/xss": {
             "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+            "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "commander": "^2.20.3",
@@ -5142,11 +5341,13 @@
             }
         },
         "node_modules/@vertigis/workflow": {
-            "version": "5.43.0",
+            "version": "5.45.1",
+            "resolved": "https://registry.npmjs.org/@vertigis/workflow/-/workflow-5.45.1.tgz",
+            "integrity": "sha512-qKV2gl9Q0lXYRt/l96d82L34Ny202VMWfDikBx+vDTQrcFxLjdw98szJxsPohE4urTFIamW8CuydXKQ6AXDA/g==",
             "dev": true,
-            "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@date-fns/utc": "^1.2.0",
+                "@esri/arcgis-html-sanitizer": "^4.0.3",
                 "@zxing/browser": "0.1.5",
                 "@zxing/library": "0.21.3",
                 "autosuggest-highlight": "^3.3.4",
@@ -5157,7 +5358,7 @@
             },
             "peerDependencies": {
                 "@arcgis/core": ">= 4.31.0  < 5.0.0",
-                "@vertigis/react-ui": ">= 16.3.1-0 < 17.0.0-0",
+                "@vertigis/react-ui": ">= 19.0.2-0 < 20.0.0-0",
                 "react": ">= 18 < 19",
                 "react-dom": ">= 18 < 19"
             }
@@ -5700,8 +5901,9 @@
         },
         "node_modules/autosuggest-highlight": {
             "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/autosuggest-highlight/-/autosuggest-highlight-3.3.4.tgz",
+            "integrity": "sha512-j6RETBD2xYnrVcoV1S5R4t3WxOlWZKyDQjkwnggDPSjF5L4jV98ZltBpvPvbkM1HtoSe5o+bNrTHyjPbieGeYA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "remove-accents": "^0.4.2"
             }
@@ -5995,9 +6197,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -6263,8 +6465,9 @@
         },
         "node_modules/clsx": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -6434,8 +6637,9 @@
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/cookie": {
@@ -6729,13 +6933,13 @@
         "node_modules/cssfilter": {
             "version": "0.0.10",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/csstype": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/data-view-buffer": {
@@ -6785,8 +6989,9 @@
         },
         "node_modules/date-fns": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+            "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -7017,8 +7222,9 @@
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
@@ -7387,8 +7593,9 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7474,8 +7681,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7598,7 +7806,8 @@
         },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         },
         "node_modules/events": {
             "version": "3.3.0",
@@ -7905,8 +8114,9 @@
         },
         "node_modules/find-root": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/find-up": {
@@ -7977,13 +8187,14 @@
         },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -8200,8 +8411,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8355,8 +8567,9 @@
         },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "dependencies": {
                 "react-is": "^16.7.0"
@@ -8364,8 +8577,9 @@
         },
         "node_modules/hoist-non-react-statics/node_modules/react-is": {
             "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/hpack.js": {
@@ -8406,20 +8620,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/html-entities": {
-            "version": "2.5.2",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/mdevils"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://patreon.com/mdevils"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "dev": true,
@@ -8449,7 +8649,8 @@
         },
         "node_modules/http-proxy": {
             "version": "1.18.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
             "dependencies": {
                 "eventemitter3": "^4.0.0",
                 "follow-redirects": "^1.0.0",
@@ -8460,8 +8661,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.7",
-            "license": "MIT",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",
@@ -9087,7 +9289,8 @@
         },
         "node_modules/is-plain-obj": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
             "engines": {
                 "node": ">=10"
             },
@@ -10615,8 +10818,9 @@
         },
         "node_modules/lodash.escape": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+            "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/lodash.merge": {
@@ -10686,8 +10890,9 @@
         },
         "node_modules/material-colors": {
             "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/math-intrinsics": {
@@ -10864,8 +11069,9 @@
             "license": "MIT"
         },
         "node_modules/multimatch/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12584,8 +12790,9 @@
         },
         "node_modules/react-color": {
             "version": "2.19.3",
+            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@icons/material": "^0.2.4",
@@ -12632,8 +12839,9 @@
         },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
@@ -12648,8 +12856,9 @@
         },
         "node_modules/reactcss": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "lodash": "^4.0.1"
@@ -12714,11 +12923,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
@@ -12796,8 +13000,9 @@
         },
         "node_modules/remove-accents": {
             "version": "0.4.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+            "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+            "dev": true
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -12815,12 +13020,14 @@
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
         "node_modules/reselect": {
-            "version": "4.1.8",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/resolve": {
@@ -13407,8 +13614,9 @@
         },
         "node_modules/source-map": {
             "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -13665,8 +13873,9 @@
         },
         "node_modules/stylis": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/supports-color": {
@@ -13849,9 +14058,10 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13909,8 +14119,9 @@
         },
         "node_modules/tinycolor2": {
             "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/tmp": {
@@ -14318,6 +14529,16 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+            "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "license": "MIT"
@@ -14509,12 +14730,14 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.1.0",
-            "license": "MIT",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
                 "@types/express": "^4.17.21",
+                "@types/express-serve-static-core": "^4.17.21",
                 "@types/serve-index": "^1.9.4",
                 "@types/serve-static": "^1.15.5",
                 "@types/sockjs": "^0.3.36",
@@ -14525,10 +14748,9 @@
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.19.2",
+                "express": "^4.21.2",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.4.0",
-                "http-proxy-middleware": "^2.0.3",
+                "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
                 "launch-editor": "^2.6.1",
                 "open": "^10.0.3",
@@ -14561,6 +14783,17 @@
                 "webpack-cli": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/webpack-dev-server/node_modules/@types/retry": {
@@ -14851,7 +15084,6 @@
             "version": "1.0.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
         "ts-loader": "~9.5.1",
         "ts-morph": "~9.1.0",
         "url-loader": "~4.1.1",
-        "webpack": "~5.94t.0",
-        "webpack-dev-server": "~5.1.0",
+        "webpack": "~5.94.0",
+        "webpack-dev-server": "~5.2.0",
         "yargs": "~17.7.2"
     },
     "devDependencies": {
@@ -64,7 +64,7 @@
         "@babel/preset-typescript": "7.26.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.30",
-        "@vertigis/workflow": "^5.43.0",
+        "@vertigis/workflow": "^5.45.1",
         "conventional-changelog-conventionalcommits": "^7.0.2",
         "cross-env": "^7.0.3",
         "execa": "^9.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -16,6 +16,12 @@
         "typescript": "^5.4.3",
         "prettier": "^3.3.1"
     },
+    "overrides": {
+        "@vertigis/react-ui": {
+            "react": ">=18 <19",
+            "react-dom": ">=18 <19"
+        }
+    },
     "browserslist": [
         "last 2 chrome versions",
         "last 2 edge versions",


### PR DESCRIPTION
`@vertigis/react-ui` allows for `react` versions 18 + 19
`@vertigis/workflow` only allows `react` version 18

You would think this would narrow the version of react that npm will try to use to 18, but instead it apparently grabs 19 to satisfy the first package, and then crashes because that doesn't satisfy the second. Maybe it's something to do with the fact that both define the package as a peer dependency? It would probably not be correct to make `react` an explicit dependency of the sdk template though.

Instead I've added an override to narrow the `@vertigis/react-ui` peer dependency to the same range as `workflow`. Although the problem will go away when workflow starts using react 19, this should probably be a permanent addition to prevent this happening again on the next version bump.