### PR TITLE
fix: Address webpack-dev-server issue with allowedHosts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit"
     },
+    "files.exclude": {
+        "node_modules": true
+    },
     "[javascript]": {
         "editor.formatOnSave": true
     },

--- a/README.md
+++ b/README.md
@@ -33,17 +33,22 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
+Runs the project in development mode. By default, Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
 
-By default all hosts are allowed. To change this, add one or more `--allowed-hosts` parameters to the command, like so:
+#### Command Line Arguments
+
+The `start` script supports the following arguments that are passed along to [webpack-dev-server](https://github.com/webpack/webpack-dev-server/tree/main?tab=readme-ov-file).
+
+- `--host` - Default is `localhost`. [[docs](https://github.com/webpack/webpack-dev-server/blob/main/DOCUMENTATION-v4.md#devserverhost)]
+- `--allowed-hosts` - Default is `all`. [[docs](https://github.com/webpack/webpack-dev-server/blob/main/DOCUMENTATION-v4.md#devserverallowedhosts)]
+
+NOTE: It is important to add `--` before the list of parameters.
+
+Example:
 
 ```sh
-npm start -- --allowed-hosts host1 --allowed-hosts host2
+npm start -- --host 0.0.0.0 --allowed-hosts auto
 ```
-
-NOTE: It is important to include the separate `--` before the list of parameters.
-
-For additional information on how this parameter is used, refer to the webpack-dev-server documentation for [devServer.allowedHosts](https://github.com/webpack/webpack-dev-server/blob/master/DOCUMENTATION-v4.md#devserverallowedhosts).
 
 ### `npm run build`
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This SDK makes it easy to create custom activity packs for [VertiGIS Studio Work
 
 ## Requirements
 
--   The latest LTS version of [Node.js](https://nodejs.org/en/download/)
--   A code editor of your choice. We recommend [Visual Studio Code](https://code.visualstudio.com/)
--   A viewer using VertiGIS Studio Workflow 5.31 or later ([VertiGIS Product Installer Downloads](https://apps.vertigisstudio.com/downloads))
-    -   VertiGIS Studio Web 5.22 or later
-    -   Workflow 5.31 widget for ArcGIS Experience Builder or later
+- The latest LTS version of [Node.js](https://nodejs.org/en/download/)
+- A code editor of your choice. We recommend [Visual Studio Code](https://code.visualstudio.com/)
+- A viewer using VertiGIS Studio Workflow 5.31 or later ([VertiGIS Product Installer Downloads](https://apps.vertigisstudio.com/downloads))
+    - VertiGIS Studio Web 5.22 or later
+    - Workflow 5.31 widget for ArcGIS Experience Builder or later
 
 ## Creating a new project
 
@@ -34,6 +34,16 @@ Interactively generate a new activity or form element.
 ### `npm start`
 
 Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
+
+By default all hosts are allowed. To change this, add one or more `--allowed-hosts` parameters to the command, like so:
+
+```sh
+npm start -- --allowed-hosts host1 --allowed-hosts host2
+```
+
+NOTE: It is important to include the separate `--` before the list of parameters.
+
+For additional information on how this parameter is used, refer to the webpack-dev-server documentation for [devServer.allowedHosts](https://github.com/webpack/webpack-dev-server/blob/master/DOCUMENTATION-v4.md#devserverallowedhosts).
 
 ### `npm run build`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
                 "ts-loader": "~9.5.1",
                 "ts-morph": "~9.1.0",
                 "url-loader": "~4.1.1",
-                "webpack": "5.101.3",
-                "webpack-dev-server": "5.2.2",
+                "webpack": "~5.101.3",
+                "webpack-dev-server": "~5.2.2",
                 "yargs": "~17.7.2"
             },
             "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
                 "ts-loader": "~9.5.1",
                 "ts-morph": "~9.1.0",
                 "url-loader": "~4.1.1",
-                "webpack": "~5.94.0",
-                "webpack-dev-server": "~5.2.0",
+                "webpack": "5.101.3",
+                "webpack-dev-server": "5.2.2",
                 "yargs": "~17.7.2"
             },
             "bin": {
@@ -4663,8 +4663,30 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
         },
         "node_modules/@types/express": {
@@ -5562,7 +5584,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.0",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -5571,11 +5595,16 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
             "peerDependencies": {
-                "acorn": "^8"
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -14614,18 +14643,22 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.94.0",
+            "version": "5.101.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
+            "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.5",
-                "@webassemblyjs/ast": "^1.12.1",
-                "@webassemblyjs/wasm-edit": "^1.12.1",
-                "@webassemblyjs/wasm-parser": "^1.12.1",
-                "acorn": "^8.7.1",
-                "acorn-import-attributes": "^1.9.5",
-                "browserslist": "^4.21.10",
+                "@types/eslint-scope": "^3.7.7",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.24.0",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.3",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -14635,11 +14668,11 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^3.2.0",
+                "schema-utils": "^4.3.2",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.10",
+                "terser-webpack-plugin": "^5.3.11",
                 "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -14861,10 +14894,40 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.3",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/webpack/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
             }
         },
         "node_modules/webpack/node_modules/eslint-scope": {
@@ -14883,6 +14946,31 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/webpack/node_modules/schema-utils": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
         "ts-loader": "~9.5.1",
         "ts-morph": "~9.1.0",
         "url-loader": "~4.1.1",
-        "webpack": "~5.94.0",
-        "webpack-dev-server": "~5.2.0",
+        "webpack": "~5.101.3",
+        "webpack-dev-server": "~5.2.2",
         "yargs": "~17.7.2"
     },
     "devDependencies": {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -29,6 +29,7 @@ const compiler = webpack(webpackConfig);
  * @type { WebpackDevServer.Configuration }
  */
 const serverConfig = {
+    allowedHosts: argv["allowed-hosts"] ?? "all",
     client: {
         logging: "none",
     },
@@ -36,7 +37,13 @@ const serverConfig = {
     headers: {
         "Access-Control-Allow-Origin": "*",
     },
+    host: "localhost",
     hot: false,
+    open: process.env.SMOKE_TEST !== "true" &&
+        process.env.OPEN_BROWSER !== "false" && {
+            target: ["main.js"],
+        },
+    port,
     server: {
         type: "https",
         options: {
@@ -45,12 +52,6 @@ const serverConfig = {
             ca: argv["ca"],
         },
     },
-    host: "localhost",
-    open: process.env.SMOKE_TEST !== "true" &&
-        process.env.OPEN_BROWSER !== "false" && {
-            target: ["main.js"],
-        },
-    port,
     static: {
         publicPath: "/",
         watch: {
@@ -60,7 +61,6 @@ const serverConfig = {
             ignored: [/node_modules/],
         },
     },
-    //stats: "minimal",
 };
 
 const devServer = new WebpackDevServer(serverConfig, compiler);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -37,7 +37,7 @@ const serverConfig = {
     headers: {
         "Access-Control-Allow-Origin": "*",
     },
-    host: "localhost",
+    host: argv["host"] ?? "localhost",
     hot: false,
     open: process.env.SMOKE_TEST !== "true" &&
         process.env.OPEN_BROWSER !== "false" && {

--- a/template/README.md
+++ b/template/README.md
@@ -10,17 +10,22 @@ Interactively generate a new activity or form element.
 
 ### `npm start`
 
-Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
+Runs the project in development mode. By default, Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
 
-By default all hosts are allowed. To change this, add one or more `--allowed-hosts` parameters to the command, like so:
+#### Command Line Arguments
+
+The `start` script supports the following arguments that are passed along to [webpack-dev-server](https://github.com/webpack/webpack-dev-server/tree/main?tab=readme-ov-file).
+
+- `--host` - Default is `localhost`. [[docs](https://github.com/webpack/webpack-dev-server/blob/main/DOCUMENTATION-v4.md#devserverhost)]
+- `--allowed-hosts` - Default is `all`. [[docs](https://github.com/webpack/webpack-dev-server/blob/main/DOCUMENTATION-v4.md#devserverallowedhosts)]
+
+NOTE: It is important to add `--` before the list of parameters.
+
+Example:
 
 ```sh
-npm start -- --allowed-hosts host1 --allowed-hosts host2
+npm start -- --host 0.0.0.0 --allowed-hosts auto
 ```
-
-NOTE: It is important to include the separate `--` before the list of parameters.
-
-For additional information on how this parameter is used, refer to the webpack-dev-server documentation for [devServer.allowedHosts](https://github.com/webpack/webpack-dev-server/blob/master/DOCUMENTATION-v4.md#devserverallowedhosts).
 
 ### `npm run build`
 
@@ -32,4 +37,4 @@ See the [section about deployment](https://developers.vertigisstudio.com/docs/wo
 
 ## Documentation
 
-Find [further documentation on the SDK](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/)
+Find [further documentation on the SDK](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/) on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).

--- a/template/README.md
+++ b/template/README.md
@@ -12,6 +12,16 @@ Interactively generate a new activity or form element.
 
 Runs the project in development mode. Your activity pack will be available at [http://localhost:5000/main.js](http://localhost:5000/main.js). The HTTPS certificate of the development server is a self-signed certificate that web browsers will warn about. To work around this open [`https://localhost:5000/main.js`](https://localhost:5000/main.js) in a web browser and allow the invalid certificate as an exception. For creating a locally-trusted HTTPS certificate see the [Configuring a HTTPS Certificate](https://developers.vertigisstudio.com/docs/workflow/sdk-web-overview/#configuring-a-https-certificate) section on the [VertiGIS Studio Developer Center](https://developers.vertigisstudio.com/docs/workflow/overview/).
 
+By default all hosts are allowed. To change this, add one or more `--allowed-hosts` parameters to the command, like so:
+
+```sh
+npm start -- --allowed-hosts host1 --allowed-hosts host2
+```
+
+NOTE: It is important to include the separate `--` before the list of parameters.
+
+For additional information on how this parameter is used, refer to the webpack-dev-server documentation for [devServer.allowedHosts](https://github.com/webpack/webpack-dev-server/blob/master/DOCUMENTATION-v4.md#devserverallowedhosts).
+
 ### `npm run build`
 
 Builds the activity pack for production to the `build` folder. It optimizes the build for the best performance.


### PR DESCRIPTION
This change resolves a problem introduced by webpack-dev-server 5.1.2. Our fix is to use a value of `"all"` for [devServer.allowedHosts](https://github.com/webpack/webpack-dev-server/blob/master/DOCUMENTATION-v4.md#devserverallowedhosts) rather than the default `"auto"`. Their documentation says that `"auto"` should accept `localhost`, but this did not seem to be the case. Upgrading webpack and webpack-dev-server seemed to fix it.

Instructions have been added to the README.md file to explain how to override this value.